### PR TITLE
modified csproj file to support the latest C#

### DIFF
--- a/Microsoft.Teams.Apps.Scrum/Microsoft.Teams.Apps.Scrum.csproj
+++ b/Microsoft.Teams.Apps.Scrum/Microsoft.Teams.Apps.Scrum.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Project will use the latest C# version during deployment. This fixes the issue with default literal not supported by azure web app.